### PR TITLE
Enhancement in switching behavior + Support for LambDynamicLights 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// Amecs Key
-	modImplementation include("de.siphalor:amecsapi-1.17:${project.amecs_version}"){
+	modImplementation include("de.siphalor:amecsapi-1.17:${project.amecs_version}") {
 		exclude group: "net.fabricmc.fabric-api"
 		exclude module: "nmuk-1.17"
 	}
@@ -40,20 +40,20 @@ dependencies {
     	exclude(group: "net.fabricmc.fabric-api")
   	}
 	// Modmenu
-	modCompileOnly modRuntime("com.terraformersmc:modmenu:${project.mod_menu_version}"),{
+	modCompileOnly modRuntime("com.terraformersmc:modmenu:${project.mod_menu_version}") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 	// Medieval Weapons
-	modCompileOnly "com.github.Globox1997:MedievalWeapons:71f49ed87a",{
-			exclude(group: "net.fabricmc.fabric-api")
-			exclude(group: "me.shedaniel.cloth")
-			exclude(group: "io.github.prospector")
-			exclude(group: "io.github.onyxstudios")
-			exclude(group: "com.github.TheIllusiveC4")
+	modCompileOnly("curse.maven:medieval-weapons-411400:3460407") {
+		exclude(group: "net.fabricmc.fabric-api")
+		exclude(group: "me.shedaniel.cloth")
+		exclude(group: "io.github.prospector")
+		exclude(group: "io.github.onyxstudios")
+		exclude(group: "com.github.TheIllusiveC4")
 	}
 	// Dungeon Weapons
-	modCompileOnly "curse.maven:mcdw-407311:3380445",{
-			exclude(group: "net.fabricmc.fabric-api")
+	modCompileOnly("curse.maven:mcdw-407311:3380445") {
+		exclude(group: "net.fabricmc.fabric-api")
 	}
 	modCompileOnly "curse.maven:enchanthelper-434579:3347061"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,19 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.17.1
-	yarn_mappings=1.17.1+build.43
-	loader_version=0.11.6
+	minecraft_version = 1.17.1
+	yarn_mappings = 1.17.1+build.61
+	loader_version = 0.12.1
 
 # Mod Properties
-	mod_version = 1.2.1
+	mod_version = 1.2.1+
 	maven_group = net.backslot
 	archives_base_name = backslot
 
 # Dependencies
-	fabric_version=0.39.0+1.17
-	cloth_config_version=5.0.34
-	mod_menu_version=2.0.5
-	amecs_version=1.1.5+mc21w16a
+	fabric_version = 0.40.8+1.17
+	cloth_config_version = 5.0.34
+	mod_menu_version = 2.0.5
+	amecs_version = 1.1.5+mc21w16a

--- a/src/main/java/net/backslot/BackSlotMain.java
+++ b/src/main/java/net/backslot/BackSlotMain.java
@@ -2,7 +2,6 @@ package net.backslot;
 
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.serializer.JanksonConfigSerializer;
-import net.backslot.compat.Compats;
 import net.backslot.config.BackSlotConfig;
 import net.backslot.network.SwitchPacket;
 import net.backslot.sound.BackSlotSounds;
@@ -23,7 +22,6 @@ public class BackSlotMain implements ModInitializer {
         AutoConfig.register(BackSlotConfig.class, JanksonConfigSerializer::new);
         CONFIG = AutoConfig.getConfigHolder(BackSlotConfig.class).getConfig();
         BackSlotSounds.init();
-        Compats.init();
         SwitchPacket.init();
     }
 

--- a/src/main/java/net/backslot/config/BackSlotConfig.java
+++ b/src/main/java/net/backslot/config/BackSlotConfig.java
@@ -15,6 +15,10 @@ public class BackSlotConfig implements ConfigData {
     public boolean disable_backslot_hud = false;
     public boolean switch_beltslot_side = false;
     public boolean offhand_switch = false;
+    public boolean offhand_shield = true;
+    public boolean offhand_fallback = true;
+    public boolean put_aside = true;
+    public boolean drop_holding = true;
     @ConfigEntry.Category("advanced_settings")
     @ConfigEntry.Gui.RequiresRestart
     @ConfigEntry.Gui.PrefixText
@@ -33,5 +37,4 @@ public class BackSlotConfig implements ConfigData {
     public float backslot_scale = 2.0F;
     @ConfigEntry.Category("advanced_settings")
     public float beltslot_scale = 2.0F;
-
 }

--- a/src/main/java/net/backslot/mixin/EntityMixin.java
+++ b/src/main/java/net/backslot/mixin/EntityMixin.java
@@ -1,0 +1,32 @@
+package net.backslot.mixin;
+
+import java.util.Arrays;
+
+import com.google.common.collect.Iterables;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+@Mixin(Entity.class)
+public class EntityMixin {
+
+    @Inject(method = "getItemsEquipped", at = @At("RETURN"), cancellable = true)
+    public void getItemsEquippedWithBackSlotItems(CallbackInfoReturnable<Iterable<ItemStack>> cir) {
+        Entity self = (Entity) (Object) this;
+        if (self instanceof PlayerEntity) {
+            PlayerEntity playerEntity = (PlayerEntity) self;
+            ItemStack backSlotStack = playerEntity.getInventory().getStack(41);
+            ItemStack beltSlotStack = playerEntity.getInventory().getStack(42);
+            Iterable<ItemStack> equippedItems = cir.getReturnValue();
+            Iterable<ItemStack> equippedBackSlotItems = Arrays.asList(backSlotStack, beltSlotStack);
+            cir.setReturnValue(Iterables.concat(equippedItems, equippedBackSlotItems));
+        }
+    }
+
+}

--- a/src/main/java/net/backslot/network/SwitchPacket.java
+++ b/src/main/java/net/backslot/network/SwitchPacket.java
@@ -7,6 +7,7 @@ import chronosacaria.mcdw.bases.McdwSpear;
 import chronosacaria.mcdw.bases.McdwStaff;
 import net.backslot.BackSlotMain;
 import net.backslot.sound.BackSlotSounds;
+import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.fabricmc.loader.api.FabricLoader;
 import net.medievalweapons.item.Big_Axe_Item;
@@ -18,15 +19,21 @@ import net.medievalweapons.item.Lance_Item;
 import net.medievalweapons.item.Long_Sword_Item;
 import net.medievalweapons.item.Small_Axe_Item;
 import net.medievalweapons.item.Thalleous_Sword_Item;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.FishingRodItem;
 import net.minecraft.item.FlintAndSteelItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.OnAStickItem;
 import net.minecraft.item.RangedWeaponItem;
 import net.minecraft.item.ShearsItem;
+import net.minecraft.item.ShieldItem;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolItem;
 import net.minecraft.item.TridentItem;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.Identifier;
@@ -35,35 +42,155 @@ public class SwitchPacket {
 
     public static final Identifier SWITCH_PACKET = new Identifier("backslot", "switch_item");
 
-    public static void init() {
-        ServerPlayNetworking.registerGlobalReceiver(SWITCH_PACKET, (server, player, handler, buffer, sender) -> {
+    public static class SwitchPacketReceiver implements ServerPlayNetworking.PlayChannelHandler {
+
+        @Override
+        public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
+                PacketByteBuf buffer, PacketSender responseSender) {
+            // target slot
             int slot = buffer.readInt();
-            int selectedSlot = (slot == 42 && BackSlotMain.CONFIG.offhand_switch) ? 40 : player.getInventory().selectedSlot;
-            ItemStack selectedStack = (slot == 42 && BackSlotMain.CONFIG.offhand_switch) ? player.getInventory().offHand.get(0) : player.getInventory().getStack(selectedSlot);
-            ItemStack slotStack = player.getInventory().getStack(slot);
-            if (isItemAllowed(selectedStack, slot)) {
-                player.getInventory().setStack(slot, selectedStack);
-                player.getInventory().setStack(selectedSlot, slotStack);
-                player.getInventory().markDirty();
-                if (BackSlotMain.CONFIG.backslot_sounds) {
-                    if (selectedStack.isEmpty() && !slotStack.isEmpty()) {
-                        if (slotStack.getItem() instanceof SwordItem) {
-                            player.world.playSound(null, player.getBlockPos(), BackSlotSounds.SHEATH_SWORD_EVENT, SoundCategory.PLAYERS, 1.0F, 1.0F);
-                        } else {
-                            player.world.playSound(null, player.getBlockPos(), SoundEvents.ITEM_ARMOR_EQUIP_GENERIC, SoundCategory.PLAYERS, 1.0F, 1.0F);
-                        }
-                    } else if (slotStack.getItem() instanceof SwordItem) {
-                        player.world.playSound(null, player.getBlockPos(), BackSlotSounds.SHEATH_SWORD_EVENT, SoundCategory.PLAYERS, 1.0F, 0.9F + player.world.random.nextFloat() * 0.2F);
-                    } else if (selectedStack.getItem() instanceof SwordItem) {
-                        player.world.playSound(null, player.getBlockPos(), BackSlotSounds.PACK_UP_ITEM_EVENT, SoundCategory.PLAYERS, 1.0F, 0.9F + player.world.random.nextFloat() * 0.2F);
-                    } else if (!selectedStack.isEmpty()) {
-                        player.world.playSound(null, player.getBlockPos(), SoundEvents.ITEM_ARMOR_EQUIP_GENERIC, SoundCategory.PLAYERS, 1.0F, 1.0F);
+
+            // player inventory and selected slot
+            PlayerInventory playerInventory = player.getInventory();
+            int selectedSlot = playerInventory.selectedSlot;
+
+            // think in a way of pulling out case (although it can be just a putting back)
+            int slotToPullOutFrom = slot;
+            int slotToPullOutTo = selectedSlot;
+
+            // pull out to offhand if pulling out from belt slot and offhand switch is on,
+            // aka belt slot always goes with offhand
+            if (BackSlotMain.CONFIG.offhand_switch) {
+                if (slotToPullOutTo != 40) {
+                    if (slotToPullOutFrom == 42) {
+                        slotToPullOutTo = 40;
                     }
                 }
             }
 
-        });
+            // shield in the back would always be pulled out to offhand
+            if (BackSlotMain.CONFIG.offhand_shield) {
+                if (slotToPullOutTo != 40) {
+                    if (slotToPullOutFrom == 41) {
+                        ItemStack backSlotStack = playerInventory.getStack(slotToPullOutFrom);
+                        boolean shouldPullOutToOffHand = backSlotStack.getItem() instanceof ShieldItem;
+                        if (shouldPullOutToOffHand) {
+                            slotToPullOutTo = 40;
+                        }
+                    }
+                }
+            }
 
+            // fallback early to offhand if failure in main hand is expected
+            if (BackSlotMain.CONFIG.offhand_fallback) {
+                if (slotToPullOutTo != 40) {
+                    ItemStack slotStack = playerInventory.getStack(slotToPullOutFrom);
+                    if (slotStack.isEmpty()) {
+                        ItemStack mainHandStack = playerInventory.getStack(slotToPullOutTo);
+                        boolean nothingsGonnaHappenWithTheMainHand = mainHandStack.isEmpty()
+                                || !isItemAllowed(mainHandStack, slotToPullOutFrom);
+                        if (nothingsGonnaHappenWithTheMainHand) {
+                            ItemStack offHandStack = playerInventory.offHand.get(0);
+                            if (isItemAllowed(offHandStack, slotToPullOutFrom)) {
+                                slotToPullOutTo = 40;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // check items in both slots
+            ItemStack stackInSlotToPullOutFrom = playerInventory.getStack(slotToPullOutFrom);
+            ItemStack stackInSlotToPullOutTo = playerInventory.getStack(slotToPullOutTo);
+
+            // switching is meaningless if both slots are empty
+            boolean bothSlotsAreEmpty = stackInSlotToPullOutFrom.isEmpty() && stackInSlotToPullOutTo.isEmpty();
+            if (bothSlotsAreEmpty) {
+                return;
+            }
+
+            // slot and stack information for putting back
+            int slotToPutBackTo = slotToPullOutFrom;
+            ItemStack stackToPutBack = stackInSlotToPullOutTo;
+
+            // check conditions
+            boolean doneSwitching = false;
+            boolean canPutBack = isItemAllowed(stackToPutBack, slotToPutBackTo);
+            if (canPutBack) {
+                // just do switch
+                playerInventory.setStack(slotToPullOutTo, stackInSlotToPullOutFrom); // pull out
+                playerInventory.setStack(slotToPutBackTo, stackToPutBack); // put back
+                playerInventory.markDirty();
+                doneSwitching = true;
+            } else if (BackSlotMain.CONFIG.put_aside) {
+                // try to put aside to an empty inventory slot if there is any
+                int slotToPutAside = playerInventory.getEmptySlot();
+                boolean canPutAside = slotToPutAside >= 0;
+                if (canPutAside) {
+                    // do switch while putting item being held aside
+                    ItemStack stackToPutAside = stackToPutBack;
+                    stackToPutBack = ItemStack.EMPTY;
+                    playerInventory.setStack(slotToPutAside, stackToPutAside); // put aside
+                    playerInventory.setStack(slotToPullOutTo, stackInSlotToPullOutFrom); // pull out
+                    playerInventory.setStack(slotToPutBackTo, stackToPutBack); // put back
+                    playerInventory.markDirty();
+                    doneSwitching = true;
+                } else if (BackSlotMain.CONFIG.drop_holding) {
+                    // even drop an item stack being held in order to make an empty space for
+                    // pulling out
+                    ItemStack stackToDrop = playerInventory.removeStack(slotToPullOutTo);
+                    ItemStack stackRemaining = playerInventory.getStack(slotToPullOutTo);
+                    // line below is from implementation of ServerPlayerEntity.dropSelectedItem()
+                    // without fully understanding what it does
+                    player.currentScreenHandler.getSlotIndex(playerInventory, slotToPullOutTo).ifPresent((i) -> {
+                        player.currentScreenHandler.setPreviousTrackedSlot(i, stackRemaining);
+                    });
+                    player.dropItem(stackToDrop, false, true);
+                    stackToPutBack = ItemStack.EMPTY;
+                    // do switch with an empty hand
+                    playerInventory.setStack(slotToPullOutTo, stackInSlotToPullOutFrom); // pull out
+                    playerInventory.setStack(slotToPutBackTo, stackToPutBack); // put back
+                    playerInventory.markDirty();
+                    doneSwitching = true;
+                }
+            }
+
+            // play sound if done switching
+            if (doneSwitching) {
+                if (BackSlotMain.CONFIG.backslot_sounds) {
+                    if (stackInSlotToPullOutTo.isEmpty() && !stackInSlotToPullOutFrom.isEmpty()) {
+                        if (stackInSlotToPullOutFrom.getItem() instanceof SwordItem) {
+                            // pulling out sword to an empty hand
+                            player.world.playSound(null, player.getBlockPos(), BackSlotSounds.SHEATH_SWORD_EVENT,
+                                    SoundCategory.PLAYERS, 1.0F, 1.0F);
+                        } else {
+                            // pulling out others to an empty hand
+                            player.world.playSound(null, player.getBlockPos(), SoundEvents.ITEM_ARMOR_EQUIP_GENERIC,
+                                    SoundCategory.PLAYERS, 1.0F, 1.0F);
+                        }
+                    } else if (stackInSlotToPullOutFrom.getItem() instanceof SwordItem) {
+                        // pulling out sword to a non empty hand
+                        player.world.playSound(null, player.getBlockPos(), BackSlotSounds.SHEATH_SWORD_EVENT,
+                                SoundCategory.PLAYERS, 1.0F, 0.9F + player.world.random.nextFloat() * 0.2F);
+                    } else if (stackInSlotToPullOutTo.getItem() instanceof SwordItem) {
+                        // putting back sword item (including while pulling out what there was other
+                        // than sword)
+                        player.world.playSound(null, player.getBlockPos(), BackSlotSounds.PACK_UP_ITEM_EVENT,
+                                SoundCategory.PLAYERS, 1.0F, 0.9F + player.world.random.nextFloat() * 0.2F);
+                    } else if (!stackInSlotToPullOutTo.isEmpty()) {
+                        // putting back other than sword
+                        player.world.playSound(null, player.getBlockPos(), SoundEvents.ITEM_ARMOR_EQUIP_GENERIC,
+                                SoundCategory.PLAYERS, 1.0F, 1.0F);
+                    }
+                }
+            }
+        }
+
+    }
+
+    public static void init() {
+        SwitchPacketReceiver receiver = new SwitchPacketReceiver();
+        ServerPlayNetworking.registerGlobalReceiver(SWITCH_PACKET, receiver);
     }
 
     public static boolean isItemAllowed(ItemStack stack, int slot) {
@@ -71,23 +198,30 @@ public class SwitchPacket {
         boolean isMedievalWeaponsModLoaded = loader.isModLoaded("medievalweapons");
         boolean isDungeonsWeaponsModLoaded = loader.isModLoaded("mcdw");
         if (slot == 42) {
-            if (isDungeonsWeaponsModLoaded && (stack.getItem() instanceof McdwHammer || stack.getItem() instanceof McdwGlaive || stack.getItem() instanceof McdwSpear
+            if (isDungeonsWeaponsModLoaded && (stack.getItem() instanceof McdwHammer
+                    || stack.getItem() instanceof McdwGlaive || stack.getItem() instanceof McdwSpear
                     || stack.getItem() instanceof McdwSickle || stack.getItem() instanceof McdwStaff)) {
                 return false;
             }
             if (isMedievalWeaponsModLoaded
-                    && (stack.getItem() instanceof Small_Axe_Item || stack.getItem() instanceof Long_Sword_Item || stack.getItem() instanceof Big_Axe_Item || stack.getItem() instanceof Javelin_Item
-                            || stack.getItem() instanceof Lance_Item || stack.getItem() instanceof Healing_Staff_Item || stack.getItem() instanceof Thalleous_Sword_Item)) {
+                    && (stack.getItem() instanceof Small_Axe_Item || stack.getItem() instanceof Long_Sword_Item
+                            || stack.getItem() instanceof Big_Axe_Item || stack.getItem() instanceof Javelin_Item
+                            || stack.getItem() instanceof Lance_Item || stack.getItem() instanceof Healing_Staff_Item
+                            || stack.getItem() instanceof Thalleous_Sword_Item)) {
                 return false;
             }
         }
 
         if (stack.isEmpty() || stack.getItem() instanceof ToolItem
-                || (slot == 41 && (stack.isIn(BackSlotMain.BACKSLOT_ITEMS) || stack.getItem() instanceof RangedWeaponItem || stack.getItem() instanceof FishingRodItem
+                || (slot == 41 && (stack.isIn(BackSlotMain.BACKSLOT_ITEMS)
+                        || stack.getItem() instanceof RangedWeaponItem || stack.getItem() instanceof FishingRodItem
                         || stack.getItem() instanceof TridentItem || stack.getItem() instanceof OnAStickItem
-                        || (isMedievalWeaponsModLoaded && (stack.getItem() instanceof Francisca_HT_Item || stack.getItem() instanceof Francisca_LT_Item))))
-                || (slot == 42 && (stack.isIn(BackSlotMain.BELTSLOT_ITEMS) || stack.getItem() instanceof FlintAndSteelItem || stack.getItem() instanceof ShearsItem
-                        || (isMedievalWeaponsModLoaded && (stack.getItem() instanceof Francisca_HT_Item || stack.getItem() instanceof Francisca_LT_Item))))) {
+                        || (isMedievalWeaponsModLoaded && (stack.getItem() instanceof Francisca_HT_Item
+                                || stack.getItem() instanceof Francisca_LT_Item))))
+                || (slot == 42 && (stack.isIn(BackSlotMain.BELTSLOT_ITEMS)
+                        || stack.getItem() instanceof FlintAndSteelItem || stack.getItem() instanceof ShearsItem
+                        || (isMedievalWeaponsModLoaded && (stack.getItem() instanceof Francisca_HT_Item
+                                || stack.getItem() instanceof Francisca_LT_Item))))) {
             return true;
         } else
             return false;

--- a/src/main/resources/backslot.mixins.json
+++ b/src/main/resources/backslot.mixins.json
@@ -7,6 +7,7 @@
     "PlayerInventoryMixin",
     "PlayerScreenHandlerMixin",
     "ServerPlayerEntityMixin",
+    "EntityMixin",
     "EntityTrackerEntryMixin",
     "ExperienceOrbEntityMixin"
   ],


### PR DESCRIPTION
1. Added configurable extensions to the existing switching behavior:

- Original:
     - always switch between main/off hand and back/belt slots, given that the item being held in hand can be put to the target slot (including an empty hand)
- Enhancements related to the original restriction:
    - even when the item being held in hand cannot be put to the target slot, just put that item aside in another inventory slot if there is any extra space, and then do the switching with the empty hand
    - even when there is no extra space for putting aside, drop the item being held in hand to the ground, and then do the switching with that empty hand
- Enhancements related to off-hand:
    - pull out shield from the back slot to the off hand always, not the main hand (there is shield icon for off-hand slot you know...)
    - try to put the item in off-hand to the target slot if nothing is gonna happen with the main hand like:
        - both the slot and the main hand are empty
        - the slot is empty but the item being held in the main hand cannot be put to the slot

2. Added [LambDynamicLights](https://www.curseforge.com/minecraft/mc-mods/lambdynamiclights) support (original issue raised in https://github.com/Globox1997/BackSlotAddon/issues/2) 

- Now the items in back/belt slots are also considered as equipped items (thought that it's logically natural to do so)
- Expected side effects:
    - In general: enchantments of items in back/belt slot would also apply on user/target damaged events
    - In specific (vanilla only):
        - arthropods will get slowness status effect if there is any bane of arthropods enchantment on back/belt slot items
            - similar to the case of holding an item with bane of arthropods in off hand slot
        - would trigger thorns effect if there is any thorns enchantment on items in back/belt slot but they would never be a candidate for durability reduction (while items in usual armor slots with thorns enchantment will)
            - similar to the case of holding an item with thorns enchantment in main/off hand slot